### PR TITLE
fix(jq): binary missing and logic corrections

### DIFF
--- a/.github/workflows/test-action-failure-critical.yaml
+++ b/.github/workflows/test-action-failure-critical.yaml
@@ -3,7 +3,7 @@ on:
   push:
   workflow_dispatch:
   schedule:
-    - cron: '30 8 * * *'
+    - cron: "30 8 * * *"
 
 jobs:
   test-action-failure-critical:
@@ -29,6 +29,10 @@ jobs:
           FAIL_BUILD: true
           SEVERITY_THRESHOLD: critical
 
+      - name: Check if action failed for any other reason then vulnerabilities found.
+        if: steps.lw-scanner.outputs.EXIT_CODE != '1'
+        run: echo "Action failed." && exit 1
+
       - name: Check if vulnerabilites were found and step failed.
-        if: steps.lw-scanner.outcome == 'failure'
+        if: steps.lw-scanner.outputs.EXIT_CODE == '1'
         run: echo "Vulnerabilities found and step failed succesfully." && exit 0

--- a/.github/workflows/test-action-failure-fixable.yaml
+++ b/.github/workflows/test-action-failure-fixable.yaml
@@ -3,7 +3,7 @@ on:
   push:
   workflow_dispatch:
   schedule:
-    - cron: '30 8 * * *'
+    - cron: "30 8 * * *"
 
 jobs:
   test-action-failure-fixable:
@@ -29,6 +29,10 @@ jobs:
           FAIL_BUILD: true
           SEVERITY_THRESHOLD: fixable
 
+      - name: Check if action failed for any other reason then vulnerabilities found.
+        if: steps.lw-scanner.outputs.EXIT_CODE != '1'
+        run: echo "Action failed." && exit 1
+
       - name: Check if vulnerabilites were found and step failed.
-        if: steps.lw-scanner.outcome == 'failure'
+        if: steps.lw-scanner.outputs.EXIT_CODE == '1'
         run: echo "Vulnerabilities found and step failed succesfully." && exit 0

--- a/.github/workflows/test-action-failure-policy.yaml
+++ b/.github/workflows/test-action-failure-policy.yaml
@@ -3,7 +3,7 @@ on:
   push:
   workflow_dispatch:
   schedule:
-    - cron: '30 8 * * *'
+    - cron: "30 8 * * *"
 
 jobs:
   test-action-failure-policy:
@@ -28,6 +28,10 @@ jobs:
           BUILD_REPORT_FILE_NAME: report.html
           USE_POLICY: true
 
+      - name: Check if action failed for any other reason then vulnerabilities found.
+        if: steps.lw-scanner.outputs.EXIT_CODE != '1'
+        run: echo "Action failed." && exit 1
+
       - name: Check if vulnerabilites were found and step failed.
-        if: steps.lw-scanner.outcome == 'failure'
+        if: steps.lw-scanner.outputs.EXIT_CODE == '1'
         run: echo "Vulnerabilities found and step failed succesfully." && exit 0

--- a/.github/workflows/test-action-failure-policy.yaml
+++ b/.github/workflows/test-action-failure-policy.yaml
@@ -28,10 +28,6 @@ jobs:
           BUILD_REPORT_FILE_NAME: report.html
           USE_POLICY: true
 
-      - name: Check if action failed for any other reason then vulnerabilities found.
-        if: steps.lw-scanner.outputs.EXIT_CODE != '1'
-        run: echo "Action failed." && exit 1
-
       - name: Check if vulnerabilites were found and step failed.
         if: steps.lw-scanner.outputs.EXIT_CODE == '1'
         run: echo "Vulnerabilities found and step failed succesfully." && exit 0

--- a/.github/workflows/test-action-scan-os-only.yaml
+++ b/.github/workflows/test-action-scan-os-only.yaml
@@ -3,7 +3,7 @@ on:
   push:
   workflow_dispatch:
   schedule:
-    - cron: '30 8 * * *'
+    - cron: "30 8 * * *"
 
 jobs:
   test-action-scan-os-only:
@@ -25,8 +25,12 @@ jobs:
           IMAGE_NAME: ghcr.io/timarenz/vulnerable-container
           IMAGE_TAG: v0.0.1
           SCAN_LIBRARY_PACKAGES: false
-          FAIL_BUILD: true
+          FAIL_BUILD: false
+
+      - name: Check if action failed for any other reason then vulnerabilities found.
+        if: steps.lw-scanner.outputs.EXIT_CODE != '1'
+        run: echo "Action failed." && exit 1
 
       - name: Check if vulnerabilites were found and step failed.
-        if: steps.lw-scanner.outcome == 'failure'
+        if: steps.lw-scanner.outputs.EXIT_CODE == '1'
         run: echo "Vulnerabilities found and step failed succesfully." && exit 0

--- a/.github/workflows/test-action-scan-os-only.yaml
+++ b/.github/workflows/test-action-scan-os-only.yaml
@@ -25,7 +25,8 @@ jobs:
           IMAGE_NAME: ghcr.io/timarenz/vulnerable-container
           IMAGE_TAG: v0.0.1
           SCAN_LIBRARY_PACKAGES: false
-          FAIL_BUILD: false
+          FAIL_BUILD: true
+          SEVERITY_THRESHOLD: critical
 
       - name: Check if action failed for any other reason then vulnerabilities found.
         if: steps.lw-scanner.outputs.EXIT_CODE != '1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM lacework/lacework-inline-scanner:latest
+FROM lacework/lacework-inline-scanner:0.2.9
 COPY ./docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/action.yaml
+++ b/action.yaml
@@ -41,6 +41,9 @@ inputs:
     description: "Use the Lacework policy managed feature (beta). If enabled this overwrites `FAIL_BUILD`and `SEVERITY_THRESHOLD`. (Default: false)"
     required: false
     default: "false"
+outputs:
+  EXIT_CODE:
+    description: "Contains exit code which should be 1 if vulnerabilites are found, any other error code implies that the scan failed."
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/action.yaml
+++ b/action.yaml
@@ -43,7 +43,7 @@ inputs:
     default: "false"
 outputs:
   EXIT_CODE:
-    description: "Contains exit code which should be 1 if vulnerabilites are found, any other error code implies that the scan failed."
+    description: "Contains exit code which should be 1 if vulnerabilites are found, any other error code implies that the scan failed. Only applicable if `USE_POLICY=false`"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,17 +35,29 @@ export LW_SCANNER_EXIT_CODE=$?
 # Exit if check is failed and policy feature not used
 if [ ${INPUT_USE_POLICY} = "false" ] && [ ${LW_SCANNER_EXIT_CODE} != 0 ]; then
     echo "Vulnerability scan failed. Failing action as security can not be guaranteed. Exiting with code 1"
+    echo "::set-output name=EXIT_CODE::1"
     exit 1
 fi
 
 # Check if needed to check build and policy feature not used
 if [ ${INPUT_USE_POLICY} = "false" ] && [ ${INPUT_FAIL_BUILD} = "true" ]; then
+  # Check if jq exists, try to install and fail if not succesful
+  if [ -f "/usr/bin/jq" ]; then
+      apk add --no-cache --quiet jq
+      if [ -f "/usr/bin/jq" ]; then
+      echo "jq not found. Not able to analyze scan results. Failing action as security can not be guaranteed. Exiting with code 2"
+      echo "::set-output name=EXIT_CODE::2"
+      exit 2
+      fi
+  fi
+
 # Check if vulnerabilites related to the severity threshold are found and if so fail action
   case $INPUT_SEVERITY_THRESHOLD in
 	fixable)
         FIXABLE_VULNS_FOUND=$(cat ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_*.json | jq '.cve.fixable_vulnerabilities')
         if [ ${FIXABLE_VULNS_FOUND} -ge 1 ]; then
             echo "${FIXABLE_VULNS_FOUND} fixable vulnerabilities found. Exiting with code 1"
+            echo "::set-output name=EXIT_CODE::1"
             exit 1
         fi
 		;;
@@ -53,6 +65,7 @@ if [ ${INPUT_USE_POLICY} = "false" ] && [ ${INPUT_FAIL_BUILD} = "true" ]; then
         CRITICAL_VULNS_FOUND=$(cat ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_*.json | jq '.cve.critical_vulnerabilities')
         if [ ${CRITICAL_VULNS_FOUND} -ge 1 ]; then
             echo "${CRITICAL_VULNS_FOUND} critical vulnerabilities found. Exiting with code 1"
+            echo "::set-output name=EXIT_CODE::1"
             exit 1
         fi
 		;;
@@ -60,6 +73,7 @@ if [ ${INPUT_USE_POLICY} = "false" ] && [ ${INPUT_FAIL_BUILD} = "true" ]; then
         HIGH_VULNS_FOUND=$(cat ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_*.json | jq '.cve.high_vulnerabilities')
         if [  ${HIGH_VULNS_FOUND} -ge 1 ]; then
             echo "${HIGH_VULNS_FOUND} high vulnerabilities found. Exiting with code 1"
+            echo "::set-output name=EXIT_CODE::1"
             exit 1
         fi
 		;;
@@ -67,6 +81,7 @@ if [ ${INPUT_USE_POLICY} = "false" ] && [ ${INPUT_FAIL_BUILD} = "true" ]; then
         MEDIUM_VULNS_FOUND=$(cat ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_*.json | jq '.cve.medium_vulnerabilities')
         if [  ${MEDIUM_VULNS_FOUND} -ge 1 ]; then
             echo "${MEDIUM_VULNS_FOUND} medium vulnerabilities found. Exiting with code 1"
+            echo "::set-output name=EXIT_CODE::1"
             exit 1
         fi
 		;;
@@ -74,6 +89,7 @@ if [ ${INPUT_USE_POLICY} = "false" ] && [ ${INPUT_FAIL_BUILD} = "true" ]; then
         LOW_VULNS_FOUND=$(cat ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_*.json | jq '.cve.low_vulnerabilities')
         if [  ${LOW_VULNS_FOUND} -ge 1 ]; then
             echo "${LOW_VULNS_FOUND} low vulnerabilities found. Exiting with code 1"
+            echo "::set-output name=EXIT_CODE::1"
             exit 1
         fi
 		;;
@@ -81,6 +97,7 @@ if [ ${INPUT_USE_POLICY} = "false" ] && [ ${INPUT_FAIL_BUILD} = "true" ]; then
         INFO_VULNS_FOUND=$(cat ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_*.json | jq '.cve.INFO_vulnerabilities')
         if [  ${INFO_VULNS_FOUND} -ge 1 ]; then
             echo "${INFO_VULNS_FOUND} info vulnerabilities found. Exiting with code 1"
+            echo "::set-output name=EXIT_CODE::1"
             exit 1
         fi
 		;;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -45,9 +45,9 @@ if [ ${INPUT_USE_POLICY} = "false" ] && [ ${INPUT_FAIL_BUILD} = "true" ]; then
   if [ ! -f "/usr/bin/jq" ]; then
       apk add --no-cache --quiet jq
       if [ ! -f "/usr/bin/jq" ]; then
-      echo "jq not found. Not able to analyze scan results. Failing action as security can not be guaranteed. Exiting with code 2"
-      echo "::set-output name=EXIT_CODE::2"
-      exit 2
+        echo "jq not found. Not able to analyze scan results. Failing action as security can not be guaranteed. Exiting with code 2"
+        echo "::set-output name=EXIT_CODE::2"
+        exit 2
       fi
   fi
 
@@ -103,5 +103,6 @@ if [ ${INPUT_USE_POLICY} = "false" ] && [ ${INPUT_FAIL_BUILD} = "true" ]; then
 		;;
   esac
 else
+    echo "::set-output name=EXIT_CODE::${LW_SCANNER_EXIT_CODE}"
     exit ${LW_SCANNER_EXIT_CODE}
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,9 +42,9 @@ fi
 # Check if needed to check build and policy feature not used
 if [ ${INPUT_USE_POLICY} = "false" ] && [ ${INPUT_FAIL_BUILD} = "true" ]; then
   # Check if jq exists, try to install and fail if not succesful
-  if [ -f "/usr/bin/jq" ]; then
+  if [ ! -f "/usr/bin/jq" ]; then
       apk add --no-cache --quiet jq
-      if [ -f "/usr/bin/jq" ]; then
+      if [ ! -f "/usr/bin/jq" ]; then
       echo "jq not found. Not able to analyze scan results. Failing action as security can not be guaranteed. Exiting with code 2"
       echo "::set-output name=EXIT_CODE::2"
       exit 2


### PR DESCRIPTION
## Summary

This PR reintroduce `jq` which is required for non-policy based vulnerability checks and also reworks workflows to test for missing `jq`.

Also this action now uses explicit `v0.2.9` version instead of `latest` of the `lw-scanner`.

## How did you test this change?

Updated the included workflows.

## Issue

ALLY-238