### PR TITLE
ci: fix test-action job

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.14.2
-RUN apk add --no-cache python3=3.9.5-r2 py3-pip=20.3.4-r1 curl=7.79.1-r1 jq=1.6-r1 bash=5.1.16-r0
+RUN apk add --no-cache python3=3.9.5-r2 py3-pip=20.3.4-r1 curl=7.79.1-r2 jq=1.6-r1 bash=5.1.16-r0
 COPY ./requirements.txt /requirements.txt
 RUN pip3 install --no-cache-dir --requirement ./requirements.txt


### PR DESCRIPTION
## Summary
Our scheduled `test-action` job has been failing for a while...

![tenor-63102882](https://user-images.githubusercontent.com/5712253/182973240-c059278e-1fa1-4e0b-b5b6-8ceaaa568d34.gif)

The problem wasn't the scanner itself but our test resource:

![Screen Shot 2022-08-04 at 4 44 31 PM](https://user-images.githubusercontent.com/5712253/182973512-ad16229b-dc03-43e8-a787-8fa16c7f076c.png)

This should fix it.

## How did you test this change?

Pipelines should pass now.

## Issue

N/A - Reported directly via Slack