### PR TITLE
chore: update scanner version to 0.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM lacework/lacework-inline-scanner:0.2.9
+FROM lacework/lacework-inline-scanner:0.7.0
 COPY ./docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
Update lw-scanner version to the latest 0.7.0 release.

## How did you test this change?
All test in this pipeline passed.

## Issue
Fixes #14 