### PR TITLE
fix: change debug to argument instead of variable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,6 @@
 
 export LW_ACCOUNT_NAME=${INPUT_LW_ACCOUNT_NAME}
 export LW_ACCESS_TOKEN=${INPUT_LW_ACCESS_TOKEN}
-export LW_SCANNER_ENABLE_DEBUGGING=${INPUT_LW_SCANNER_ENABLE_DEBUGGING:-false}
 
 # Disable update prompt for lw-scanner if newer version is available unless explicitly set
 export LW_SCANNER_DISABLE_UPDATES=${LW_SCANNER_DISABLE_UPDATES:-true}
@@ -20,6 +19,9 @@ if [ ${INPUT_SAVE_BUILD_REPORT} = "true" ]; then
 fi
 if [ ! -z "${INPUT_BUILD_REPORT_FILE_NAME}" ]; then
     export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --html-file ${INPUT_BUILD_REPORT_FILE_NAME}"
+fi
+if [ ${INPUT_LW_SCANNER_ENABLE_DEBUGGING} = "true" ]; then
+    export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --debug"
 fi
 
 # Remove old scanner evaluation, if cached somehow


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
-->

## Summary
Fixes my last PR that instead sets the debug argument as the env variable is currently not working
