### PR TITLE
ci: fix release script to fint latest version

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -254,8 +254,9 @@ prerequisites() {
 find_latest_version() {
   local _pattern="v[0-9]\+.[0-9]\+.[0-9]\+"
   local _versions
+  local _latest_version
   _versions=$(git ls-remote --tags --quiet | grep $_pattern | tr '/' ' ' | tr 'v' ' ' | awk '{print $NF}')
-  echo "v$_versions" | tr '.' ' ' | sort -nr -k 1 -k 2 -k 3 | tr ' ' '.' | head -1
+  _latest_version=$(echo "v$_versions" | tr '.' ' ' | sort -nr -k 1 -k 2 -k 3 | tr ' ' '.' | head -1)
 }
 
 check_for_minor_version_bump() {


### PR DESCRIPTION
## Summary

The function `find_latest_version()` had a problem where it wasn't returning the version
without the `v` at the beginning

## How did you test this change?
We are going to trigger a release after this PR.

## Issue
N/A