### PR TITLE
feat(cli): add option to specify additional parameters for the lacework scanner cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ Options:
 | `IMAGE_NAME`               | Name of the container to be scanned, for example `node`                                                                                             |                                        |
 | `IMAGE_TAG`                | Tag of the container image you want to scan, for example `12.18.2-alpine`                                                                           |                                        |
 | `SCAN_LIBRARY_PACKAGES`    | Also scan software packages                                                                                                                         | `true`                                 |
-| `SAVE_RESULTS_IN_LACEWORK` | Save results to your Lacework account                                                                                                               | `true`                                 |
+| `SAVE_RESULTS_IN_LACEWORK` | Save results to your Lacework account                                                                                                               | `false`                                 |
 | `SAVE_BUILD_REPORT`        | Saves the evaluation report as a local HTML file.                                                                                                   | `false`                                |
 | `BUILD_REPORT_FILE_NAME`   | Specify custom file name for the HTML evalutation report                                                                                            | `<OS_TYPE>-<IMAGE_DIGEST_SHA256>.html` |
 | `DEBUGGING`                | Enables debug logging from scanner                                                                                                                  | `false`                                |
 | `PRETTY_OUTPUT`            | Renders table borders and adds color to Severity column in the output of the evaluation results                                                     | `true`                                 |
 | `SIMPLE_OUTPUT`            | Displays evaluation results without Introduced in `Layer` and `File Path` columns.                                                                  | `true`                                 |
 | `COLOR_OUTPUT`             | Colors are rendered in evaluation results when the `PRETTY_OUTPUT` option is enabled.                                                               | `true`                                 |
-| `ADDITINONAL_PARAMETERS`   | Additional custom parameters for the lacework scanner cli. (see [docs](https://docs.lacework.com/onboarding/integrate-inline-scanner#global-flags)) |                                        |
+| `ADDITIONAL_PARAMETERS`   | Additional parameters/flags. Only [global](https://docs.lacework.com/onboarding/integrate-inline-scanner#global-flags) and [`image evalute`](https://docs.lacework.com/onboarding/integrate-inline-scanner#flags-for-image-evaluate) flags are supported. |                                        |
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To add the scanner to your workflow:
 - uses: lacework/lw-scanner-action@v1.2.0
   name: Scan container image for vulnerabilities using Lacework
   with:
-    LW_ACCOUNT_NAME: ${{ secrets.LW_ACCOUNT_NAME }} 
+    LW_ACCOUNT_NAME: ${{ secrets.LW_ACCOUNT_NAME }}
     LW_ACCESS_TOKEN: ${{ secrets.LW_ACCESS_TOKEN }}
     IMAGE_NAME: techallylw/vulnerable-container
     IMAGE_TAG: v0.0.1
@@ -22,37 +22,38 @@ To add the scanner to your workflow:
 
 Options:
 
-| Option                     | Description                                                                                                                                      | Default                                |
-|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
-| `LW_ACCOUNT_NAME`          | Your Lacework account name (see [docs](https://docs.lacework.com/integrate-inline-scanner#configure-authentication-using-environment-variables)) |                                        |
-| `LW_ACCESS_TOKEN`          | Authorization token (see [docs](https://docs.lacework.com/integrate-inline-scanner#obtain-the-inline-scanner-and-authorization-token))           |                                        |
-| `IMAGE_NAME`               | Name of the container to be scanned, for example `node`                                                                                          |                                        |
-| `IMAGE_TAG`                | Tag of the container image you want to scan, for example `12.18.2-alpine`                                                                        |                                        |
-| `SCAN_LIBRARY_PACKAGES`    | Also scan software packages                                                                                                                      | `true`                                 |
-| `SAVE_RESULTS_IN_LACEWORK` | Save results to your Lacework account                                                                                                            | `true`                                 |
-| `SAVE_BUILD_REPORT`        | Saves the evaluation report as a local HTML file.                                                                                                | `false`                                |
-| `BUILD_REPORT_FILE_NAME`   | Specify custom file name for the HTML evalutation report                                                                                         | `<OS_TYPE>-<IMAGE_DIGEST_SHA256>.html` |
-| `DEBUGGING`                | Enables debug logging from scanner                                                                                                               | `false`                                |
-| `PRETTY_OUTPUT`            | Renders table borders and adds color to Severity column in the output of the evaluation results                                                  | `true`                                 |
-| `SIMPLE_OUTPUT`            | Displays evaluation results without Introduced in `Layer` and `File Path` columns.                                                               | `true`                                 |
-| `COLOR_OUTPUT`             | Colors are rendered in evaluation results when the `PRETTY_OUTPUT` option is enabled.                                                            | `true`                                 |
+| Option                     | Description                                                                                                                                         | Default                                |
+|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| `LW_ACCOUNT_NAME`          | Your Lacework account name (see [docs](https://docs.lacework.com/integrate-inline-scanner#configure-authentication-using-environment-variables))    |                                        |
+| `LW_ACCESS_TOKEN`          | Authorization token (see [docs](https://docs.lacework.com/integrate-inline-scanner#obtain-the-inline-scanner-and-authorization-token))              |                                        |
+| `IMAGE_NAME`               | Name of the container to be scanned, for example `node`                                                                                             |                                        |
+| `IMAGE_TAG`                | Tag of the container image you want to scan, for example `12.18.2-alpine`                                                                           |                                        |
+| `SCAN_LIBRARY_PACKAGES`    | Also scan software packages                                                                                                                         | `true`                                 |
+| `SAVE_RESULTS_IN_LACEWORK` | Save results to your Lacework account                                                                                                               | `true`                                 |
+| `SAVE_BUILD_REPORT`        | Saves the evaluation report as a local HTML file.                                                                                                   | `false`                                |
+| `BUILD_REPORT_FILE_NAME`   | Specify custom file name for the HTML evalutation report                                                                                            | `<OS_TYPE>-<IMAGE_DIGEST_SHA256>.html` |
+| `DEBUGGING`                | Enables debug logging from scanner                                                                                                                  | `false`                                |
+| `PRETTY_OUTPUT`            | Renders table borders and adds color to Severity column in the output of the evaluation results                                                     | `true`                                 |
+| `SIMPLE_OUTPUT`            | Displays evaluation results without Introduced in `Layer` and `File Path` columns.                                                                  | `true`                                 |
+| `COLOR_OUTPUT`             | Colors are rendered in evaluation results when the `PRETTY_OUTPUT` option is enabled.                                                               | `true`                                 |
+| `ADDITINONAL_PARAMETERS`   | Additional custom parameters for the lacework scanner cli. (see [docs](https://docs.lacework.com/onboarding/integrate-inline-scanner#global-flags)) |                                        |
 
 ## Example
 
 ```yaml
 jobs:
-    build:
-        steps:
-            - uses: lacework/lw-scanner-action@v1.2.0
-              name: Scan container images for vulnerabitilies using Lacework
-              with:
-                LW_ACCOUNT_NAME: ${{ secrets.LW_ACCOUNT_NAME }} 
-                LW_ACCESS_TOKEN: ${{ secrets.LW_ACCESS_TOKEN }}
-                IMAGE_NAME: techallylw/vulnerable-container
-                IMAGE_TAG: v0.0.1
-                SAVE_RESULTS_IN_LACEWORK: true
-                SAVE_BUILD_REPORT: true
-                BUILD_REPORT_FILE_NAME: myreport.html
+  build:
+    steps:
+      - uses: lacework/lw-scanner-action@v1.2.0
+        name: Scan container images for vulnerabitilies using Lacework
+        with:
+          LW_ACCOUNT_NAME: ${{ secrets.LW_ACCOUNT_NAME }}
+          LW_ACCESS_TOKEN: ${{ secrets.LW_ACCESS_TOKEN }}
+          IMAGE_NAME: techallylw/vulnerable-container
+          IMAGE_TAG: v0.0.1
+          SAVE_RESULTS_IN_LACEWORK: true
+          SAVE_BUILD_REPORT: true
+          BUILD_REPORT_FILE_NAME: myreport.html
 ```
 
 ## Contributing

--- a/action.yaml
+++ b/action.yaml
@@ -45,6 +45,9 @@ inputs:
     description: "Colors are rendered in evaluation results when the `PRETTY_OUTPUT` option is enabled. (Default: true)"
     required: false
     default: "true"
+  ADDITIONAL_PARAMETERS:
+    description: "Additional custom parameters for the lacework scanner cli"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -61,6 +64,7 @@ runs:
     - ${{ inputs.PRETTY_OUTPUT }}
     - ${{ inputs.SIMPLE_OUTPUT }}
     - ${{ inputs.COLOR_OUTPUT }}
+    - ${{ inputs.ADDITIONAL_PARAMETERS }}
 branding:
   icon: "alert-triangle"
   color: "blue"

--- a/action.yaml
+++ b/action.yaml
@@ -46,7 +46,7 @@ inputs:
     required: false
     default: "true"
   ADDITIONAL_PARAMETERS:
-    description: "Additional custom parameters for the lacework scanner cli"
+    description: "Additional parameters/flags. Only global and `image evalute` flags are supported."
     required: false
 runs:
   using: "docker"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,6 +32,9 @@ fi
 if [ ${INPUT_COLOR_OUTPUT} = "false" ]; then
     export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --no-color"
 fi
+if [ ! -z "${INPUT_ADDITIONAL_PARAMETERS}" ]; then
+    export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} ${INPUT_ADDITIONAL_PARAMETERS}"
+fi
 
 # Remove old scanner evaluation, if cached somehow
 rm ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_*.json &>/dev/null || true


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This new option will enable users to authenticate against a private registry for example by providing --docker-* parameters.


## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

I built the image locally and tested the additional --docker-* parameter to scan an Image in our private AWS ECR.

## Issue

<!--
  Include the link to a Jira/Github issue
-->

Described in Issue https://github.com/lacework/lw-scanner-action/issues/33