### PR TITLE
ci: update the version-bump script argument check

### DIFF
--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -16,6 +16,7 @@ if [[ "${1:-}" == "" ]]; then
   echo "ERROR: Unable to update version. Please provide the new version to update."
 elif [[ "${1:-}" == "undefined" ]]; then
   echo "ERROR: SCANNER_VERSION variable not passed to codefresh job. Please check the pipeline."
+  exit 1
 fi
 
 _scanner_version=$1

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -14,6 +14,8 @@ readonly git_email="tech-ally@lacework.net"
 
 if [[ "${1:-}" == "" ]]; then
   echo "ERROR: Unable to update version. Please provide the new version to update."
+elif [[ "${1:-}" == "undefined" ]]; then
+  echo "ERROR: SCANNER_VERSION variable not passed to codefresh job. Please check the pipeline."
 fi
 
 _scanner_version=$1


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
-->

## Summary

Updating the version-bump script for a specific check for 'undefined' which is the default, invalid value for the codefresh pipeline. This will spew out a dedicated error message and exit the script.

## How did you test this change?

Manual execution of script passing in the default value

## Issue

https://lacework.atlassian.net/browse/DPE-2399
