### PR TITLE
fix: exit code management

### DIFF
--- a/.github/workflows/test-action-summary.yaml
+++ b/.github/workflows/test-action-summary.yaml
@@ -21,7 +21,6 @@ jobs:
           tags: ${{ github.repository }}:latest
 
       - name: lw-scanner
-        id: lw-scanner
         uses: ./
         with:
           LW_ACCOUNT_NAME: ${{ secrets.LW_ACCOUNT_NAME }}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -45,7 +45,9 @@ rm ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evalua
   --build-id ${GITHUB_RUN_ID} \
   --data-directory ${GITHUB_WORKSPACE} \
   --policy \
-  --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS} | tee results.stdout
+  --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS} 1> results.stdout
+
+export EXIT_CODE=$?
 
 if [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
     echo "### Security Scan" >> $GITHUB_STEP_SUMMARY
@@ -53,3 +55,5 @@ if [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
     cat results.stdout >> $GITHUB_STEP_SUMMARY
     echo "</pre>" >> $GITHUB_STEP_SUMMARY
 fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
Fix #52 and referring to [this comment](https://github.com/lacework/lw-scanner-action/pull/52#issuecomment-1633790890) 

## Summary

With the redirection of stdout to the `tee` command, the code error return by `lw-scanner` isn't manage.
With this fix, we're able to fail and display the result of the scanner and fail with the waiting error code for Policy Violations.

## How did you test this change?

There's already a test which verify that the fail is managed.
However, not very easy to test the behavior with a waiting error code for policy violations due to this the fast that's configure et trigger on the lacework instance.