### PR TITLE
feat: add github summary integration

### DIFF
--- a/.github/workflows/test-action-summary.yaml
+++ b/.github/workflows/test-action-summary.yaml
@@ -1,4 +1,4 @@
-name: test-action-blocked
+name: test-action-summary
 on:
   push:
   pull_request:

--- a/.github/workflows/test-action-summary.yaml
+++ b/.github/workflows/test-action-summary.yaml
@@ -1,0 +1,32 @@
+name: test-action-blocked
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 8 * * *"
+
+jobs:
+  test-action-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Pull Docker image
+        run: docker image pull techallylw/vulnerable-container:v0.0.1
+
+      - name: lw-scanner with summury
+        id: lw-scanner-with-summary
+        continue-on-error: true
+        uses: ./
+        with:
+          LW_ACCOUNT_NAME: ${{ secrets.LW_ACCOUNT_NAME }}
+          LW_ACCESS_TOKEN: ${{ secrets.LW_ACCESS_TOKEN_POLICY }}
+          IMAGE_NAME: techallylw/vulnerable-container
+          IMAGE_TAG: v0.0.1
+          RESULTS_IN_GITHUB_SUMMARY: "true"
+
+      - name: Check if step with summary did fail as expected based on policy.
+        if: steps.lw-scanner-with-summary.outcome != 'failure'
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -22,33 +22,38 @@ To add the scanner to your workflow:
 
 Options:
 
-| Option                     | Description                                                                                                                                         | Default                                |
-|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
-| `LW_ACCOUNT_NAME`          | Your Lacework account name (see [docs](https://docs.lacework.com/integrate-inline-scanner#configure-authentication-using-environment-variables))    |                                        |
-| `LW_ACCESS_TOKEN`          | Authorization token (see [docs](https://docs.lacework.com/integrate-inline-scanner#obtain-the-inline-scanner-and-authorization-token))              |                                        |
-| `IMAGE_NAME`               | Name of the container to be scanned, for example `node`                                                                                             |                                        |
-| `IMAGE_TAG`                | Tag of the container image you want to scan, for example `12.18.2-alpine`                                                                           |                                        |
-| `SCAN_LIBRARY_PACKAGES`    | Also scan software packages                                                                                                                         | `true`                                 |
-| `SAVE_RESULTS_IN_LACEWORK` | Save results to your Lacework account                                                                                                               | `false`                                 |
-| `SAVE_BUILD_REPORT`        | Saves the evaluation report as a local HTML file.                                                                                                   | `false`                                |
-| `BUILD_REPORT_FILE_NAME`   | Specify custom file name for the HTML evalutation report                                                                                            | `<OS_TYPE>-<IMAGE_DIGEST_SHA256>.html` |
-| `DEBUGGING`                | Enables debug logging from scanner                                                                                                                  | `false`                                |
-| `PRETTY_OUTPUT`            | Renders table borders and adds color to Severity column in the output of the evaluation results                                                     | `true`                                 |
-| `SIMPLE_OUTPUT`            | Displays evaluation results without Introduced in `Layer` and `File Path` columns.                                                                  | `true`                                 |
-| `COLOR_OUTPUT`             | Colors are rendered in evaluation results when the `PRETTY_OUTPUT` option is enabled.                                                               | `true`                                 |
-| `ADDITIONAL_PARAMETERS`   | Additional parameters/flags. Only [global](https://docs.lacework.com/onboarding/integrate-inline-scanner#global-flags) and [`image evalute`](https://docs.lacework.com/onboarding/integrate-inline-scanner#flags-for-image-evaluate) flags are supported. |                                        |
+| Option                      | Description                                                                                                                                                                                                                                               | Default                                |
+|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| `LW_ACCOUNT_NAME`           | Your Lacework account name (see [docs](https://docs.lacework.com/integrate-inline-scanner#configure-authentication-using-environment-variables))                                                                                                          |                                        |
+| `LW_ACCESS_TOKEN`           | Authorization token (see [docs](https://docs.lacework.com/integrate-inline-scanner#obtain-the-inline-scanner-and-authorization-token))                                                                                                                    |                                        |
+| `IMAGE_NAME`                | Name of the container to be scanned, for example `node`                                                                                                                                                                                                   |                                        |
+| `IMAGE_TAG`                 | Tag of the container image you want to scan, for example `12.18.2-alpine`                                                                                                                                                                                 |                                        |
+| `SCAN_LIBRARY_PACKAGES`     | Also scan software packages                                                                                                                                                                                                                               | `true`                                 |
+| `SAVE_RESULTS_IN_LACEWORK`  | Save results to your Lacework account                                                                                                                                                                                                                     | `false`                                |
+| `SAVE_BUILD_REPORT`         | Saves the evaluation report as a local HTML file.                                                                                                                                                                                                         | `false`                                |
+| `BUILD_REPORT_FILE_NAME`    | Specify custom file name for the HTML evalutation report                                                                                                                                                                                                  | `<OS_TYPE>-<IMAGE_DIGEST_SHA256>.html` |
+| `DEBUGGING`                 | Enables debug logging from scanner                                                                                                                                                                                                                        | `false`                                |
+| `PRETTY_OUTPUT`             | Renders table borders and adds color to Severity column in the output of the evaluation results                                                                                                                                                           | `true`                                 |
+| `SIMPLE_OUTPUT`             | Displays evaluation results without Introduced in `Layer` and `File Path` columns.                                                                                                                                                                        | `true`                                 |
+| `COLOR_OUTPUT`              | Colors are rendered in evaluation results when the `PRETTY_OUTPUT` option is enabled.                                                                                                                                                                     | `true`                                 |
+| `ADDITIONAL_PARAMETERS`     | Additional parameters/flags. Only [global](https://docs.lacework.com/onboarding/integrate-inline-scanner#global-flags) and [`image evalute`](https://docs.lacework.com/onboarding/integrate-inline-scanner#flags-for-image-evaluate) flags are supported. |                                        |
+| `RESULTS_IN_GITHUB_SUMMARY` | Display results in Github Summary. Further information [here](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/)                                                                                                            | `false`                                |
 
 # Environment variables
-The Lacework Integrate Inline Scanner uses environment variables for additional configuration parameters. By default this action uses the following environment variables and default values.
 
-| Environment variable name | Default value |
-|---------------------------|---------------|
-| LW_ACCOUNT_NAME | GitHub actions input variable `LW_ACCOUNT_NAME` |
-| LW_ACCESS_TOKEN | GitHub actions input variable `LW_ACCESS_TOKEN` |
-| LW_SCANNER_DISABLE_UPDATES | `true` |
+The Lacework Integrate Inline Scanner uses environment variables for additional configuration parameters. By default
+this action uses the following environment variables and default values.
 
-Additional enviroment variables can be set within the GitHub Action step itself (see [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsenv)).
-This way, for example, you can enable offline scanning of Java images, see [Scan Java Images Offline](https://docs.lacework.com/onboarding/integrate-inline-scanner#scan-java-images-offline).
+| Environment variable name  | Default value                                   |
+|----------------------------|-------------------------------------------------|
+| LW_ACCOUNT_NAME            | GitHub actions input variable `LW_ACCOUNT_NAME` |
+| LW_ACCESS_TOKEN            | GitHub actions input variable `LW_ACCESS_TOKEN` |
+| LW_SCANNER_DISABLE_UPDATES | `true`                                          |
+
+Additional enviroment variables can be set within the GitHub Action step itself (
+see [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsenv)).
+This way, for example, you can enable offline scanning of Java images,
+see [Scan Java Images Offline](https://docs.lacework.com/onboarding/integrate-inline-scanner#scan-java-images-offline).
 
 ## Example
 

--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,10 @@ inputs:
   ADDITIONAL_PARAMETERS:
     description: "Additional parameters/flags. Only global and `image evalute` flags are supported."
     required: false
+  RESULTS_IN_GITHUB_SUMMARY:
+    description: "Display results in github summary. (Default: false)"
+    required: false
+    default: "false"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,7 +29,7 @@ fi
 if [ ${INPUT_SIMPLE_OUTPUT} = "true" ]; then
     export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --simple"
 fi
-if [ ${INPUT_COLOR_OUTPUT} = "false" ]; then
+if [ ${INPUT_COLOR_OUTPUT} = "false" ] || [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
     export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --no-color"
 fi
 if [ ! -z "${INPUT_ADDITIONAL_PARAMETERS}" ]; then
@@ -40,5 +40,20 @@ fi
 rm ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_*.json &>/dev/null || true
 
 # Run scanner
-/opt/lacework/lw-scanner image evaluate ${INPUT_IMAGE_NAME} ${INPUT_IMAGE_TAG} --build-plan ${GITHUB_REPOSITORY} \
-  --build-id ${GITHUB_RUN_ID} --data-directory ${GITHUB_WORKSPACE}  --policy --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS}
+/opt/lacework/lw-scanner image evaluate ${INPUT_IMAGE_NAME} ${INPUT_IMAGE_TAG} \
+  --build-plan ${GITHUB_REPOSITORY} \
+  --build-id ${GITHUB_RUN_ID} \
+  --data-directory ${GITHUB_WORKSPACE} \
+  --policy \
+  --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS} 1> results.stdout
+
+export SCANNER_EXIT_CODE=$?
+
+if [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
+    echo "### Security Scan" >> $GITHUB_STEP_SUMMARY
+    echo "<pre>" >> $GITHUB_STEP_SUMMARY
+    cat results.stdout >> $GITHUB_STEP_SUMMARY
+    echo "</pre>" >> $GITHUB_STEP_SUMMARY
+fi
+
+exit ${SCANNER_EXIT_CODE}


### PR DESCRIPTION
Close https://github.com/lacework/lw-scanner-action/issues/56

## Summary

The same of https://github.com/lacework/lw-scanner-action/pull/52 but this time, the script is able to managed the exit code of `lw-scanner`.

## How did you test this change?

- in my own fork https://github.com/jycamier/lw-scanner-action/pull/1 with 2 type of connection to my own lacework instance :  
	- without policy evaluation
	- with policy evaluation

