### PR TITLE
fix: output for non job-summary runs

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,7 +44,8 @@ rm ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evalua
     --build-id ${GITHUB_RUN_ID} \
     --data-directory ${GITHUB_WORKSPACE} \
     --policy \
-    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS} 1> tee results.stdout
+    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS} 1> | tee results.stdout
+
 export SCANNER_EXIT_CODE=$?
 
 if [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,7 +46,7 @@ if [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
     --build-id ${GITHUB_RUN_ID} \
     --data-directory ${GITHUB_WORKSPACE} \
     --policy \
-    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS}
+    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS} 1> results.stdout
     export SCANNER_EXIT_CODE=$?
     echo "### Security Scan" >> $GITHUB_STEP_SUMMARY
     echo "<pre>" >> $GITHUB_STEP_SUMMARY

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -53,7 +53,7 @@ if [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
     cat results.stdout >> $GITHUB_STEP_SUMMARY
     echo "</pre>" >> $GITHUB_STEP_SUMMARY
     exit ${SCANNER_EXIT_CODE}
-elif
+else
     # Run scanner in default mode with output to console
     /opt/lacework/lw-scanner image evaluate ${INPUT_IMAGE_NAME} ${INPUT_IMAGE_TAG} \
     --build-plan ${GITHUB_REPOSITORY} \
@@ -62,5 +62,3 @@ elif
     --policy \
     --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS}
 fi
-
-

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -39,26 +39,19 @@ fi
 # Remove old scanner evaluation, if cached somehow
 rm ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_*.json &>/dev/null || true
 
-if [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
-    # Run scanner and store resulst as github job summary and no output to console
-    /opt/lacework/lw-scanner image evaluate ${INPUT_IMAGE_NAME} ${INPUT_IMAGE_TAG} \
+/opt/lacework/lw-scanner image evaluate ${INPUT_IMAGE_NAME} ${INPUT_IMAGE_TAG} \
     --build-plan ${GITHUB_REPOSITORY} \
     --build-id ${GITHUB_RUN_ID} \
     --data-directory ${GITHUB_WORKSPACE} \
     --policy \
-    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS} 1> results.stdout
-    export SCANNER_EXIT_CODE=$?
+    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS} 1> tee results.stdout
+export SCANNER_EXIT_CODE=$?
+
+if [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
     echo "### Security Scan" >> $GITHUB_STEP_SUMMARY
     echo "<pre>" >> $GITHUB_STEP_SUMMARY
     cat results.stdout >> $GITHUB_STEP_SUMMARY
     echo "</pre>" >> $GITHUB_STEP_SUMMARY
-    exit ${SCANNER_EXIT_CODE}
-else
-    # Run scanner in default mode with output to console
-    /opt/lacework/lw-scanner image evaluate ${INPUT_IMAGE_NAME} ${INPUT_IMAGE_TAG} \
-    --build-plan ${GITHUB_REPOSITORY} \
-    --build-id ${GITHUB_RUN_ID} \
-    --data-directory ${GITHUB_WORKSPACE} \
-    --policy \
-    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS}
 fi
+
+exit ${SCANNER_EXIT_CODE}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -o pipefail
+
 # Set Lacework credentials as inline scanner environment variable
 export LW_ACCOUNT_NAME=${INPUT_LW_ACCOUNT_NAME}
 export LW_ACCESS_TOKEN=${INPUT_LW_ACCESS_TOKEN}
@@ -44,7 +46,7 @@ rm ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evalua
     --build-id ${GITHUB_RUN_ID} \
     --data-directory ${GITHUB_WORKSPACE} \
     --policy \
-    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS} 1> | tee results.stdout
+    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS} | tee results.stdout
 
 export SCANNER_EXIT_CODE=$?
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+# Set Lacework credentials as inline scanner environment variable
 export LW_ACCOUNT_NAME=${INPUT_LW_ACCOUNT_NAME}
 export LW_ACCESS_TOKEN=${INPUT_LW_ACCESS_TOKEN}
 
@@ -29,7 +29,7 @@ fi
 if [ ${INPUT_SIMPLE_OUTPUT} = "true" ]; then
     export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --simple"
 fi
-if [ ${INPUT_COLOR_OUTPUT} = "false" ] || [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
+if [ ${INPUT_COLOR_OUTPUT} = "false" ]; then
     export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --no-color"
 fi
 if [ ! -z "${INPUT_ADDITIONAL_PARAMETERS}" ]; then
@@ -39,21 +39,28 @@ fi
 # Remove old scanner evaluation, if cached somehow
 rm ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_*.json &>/dev/null || true
 
-# Run scanner
-/opt/lacework/lw-scanner image evaluate ${INPUT_IMAGE_NAME} ${INPUT_IMAGE_TAG} \
-  --build-plan ${GITHUB_REPOSITORY} \
-  --build-id ${GITHUB_RUN_ID} \
-  --data-directory ${GITHUB_WORKSPACE} \
-  --policy \
-  --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS} 1> results.stdout
-
-export SCANNER_EXIT_CODE=$?
-
 if [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
+    # Run scanner and store resulst as github job summary and no output to console
+    /opt/lacework/lw-scanner image evaluate ${INPUT_IMAGE_NAME} ${INPUT_IMAGE_TAG} \
+    --build-plan ${GITHUB_REPOSITORY} \
+    --build-id ${GITHUB_RUN_ID} \
+    --data-directory ${GITHUB_WORKSPACE} \
+    --policy \
+    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS}
+    export SCANNER_EXIT_CODE=$?
     echo "### Security Scan" >> $GITHUB_STEP_SUMMARY
     echo "<pre>" >> $GITHUB_STEP_SUMMARY
     cat results.stdout >> $GITHUB_STEP_SUMMARY
     echo "</pre>" >> $GITHUB_STEP_SUMMARY
+    exit ${SCANNER_EXIT_CODE}
+elif
+    # Run scanner in default mode with output to console
+    /opt/lacework/lw-scanner image evaluate ${INPUT_IMAGE_NAME} ${INPUT_IMAGE_TAG} \
+    --build-plan ${GITHUB_REPOSITORY} \
+    --build-id ${GITHUB_RUN_ID} \
+    --data-directory ${GITHUB_WORKSPACE} \
+    --policy \
+    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS}
 fi
 
-exit ${SCANNER_EXIT_CODE}
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,7 +29,7 @@ fi
 if [ ${INPUT_SIMPLE_OUTPUT} = "true" ]; then
     export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --simple"
 fi
-if [ ${INPUT_COLOR_OUTPUT} = "false" ]; then
+if [ ${INPUT_COLOR_OUTPUT} = "false" ] || [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
     export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --no-color"
 fi
 if [ ! -z "${INPUT_ADDITIONAL_PARAMETERS}" ]; then


### PR DESCRIPTION
## Summary
With the introduction of the ability to create  job summaries unfortunately the default outputs where removed. This PR restores the default output if no job summary is created.

## How did you test this change?

Automated testing