### PR TITLE
chore(tests): Use newer docker actions as old version use deprecated node version.

### DIFF
--- a/.github/workflows/test-action-blocked.yaml
+++ b/.github/workflows/test-action-blocked.yaml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull Docker image
         run: docker image pull techallylw/vulnerable-container:v0.0.1
 
       - name: Build lw-scanner action container image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           load: true

--- a/.github/workflows/test-action-blocked.yaml
+++ b/.github/workflows/test-action-blocked.yaml
@@ -17,7 +17,7 @@ jobs:
         run: docker image pull techallylw/vulnerable-container:v0.0.1
 
       - name: Build lw-scanner action container image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           load: true

--- a/.github/workflows/test-action-summary.yaml
+++ b/.github/workflows/test-action-summary.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull Docker image
         run: docker image pull techallylw/vulnerable-container:v0.0.1

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull Docker image
         run: docker image pull techallylw/vulnerable-container:v0.0.1
 
       - name: Build lw-scanner action container image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           load: true

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -17,7 +17,7 @@ jobs:
         run: docker image pull techallylw/vulnerable-container:v0.0.1
 
       - name: Build lw-scanner action container image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           load: true


### PR DESCRIPTION
## Summary
Upgraded both `actions/checkout@v4` and `docker/build-push-action@v5` as they still use node 16 which is deprecated.

## How did you test this change?
Automated testing.