### PR TITLE
fix: drop root privileges during scanning to avoid EACCES errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM alpine:3.17 AS builder
 
 # Install a statically-linked BusyBox and su-exec
-RUN apk add --no-cache busybox-static su-exec
+RUN apk add --no-cache busybox-static su-exec dos2unix
 
 # Create a directory to hold our binaries
 RUN mkdir /bundle
@@ -15,6 +15,7 @@ RUN cp /sbin/su-exec /bundle/su-exec
 
 # Copy and chmod your entrypoint script
 COPY docker-entrypoint.sh /bundle/docker-entrypoint.sh
+RUN dos2unix /bundle/docker-entrypoint.sh
 RUN chmod +x /bundle/docker-entrypoint.sh
 
 # --------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
 FROM lacework/lacework-inline-scanner:0.27.0
+
+# install su-exec/gosu
+# alpine-based
+RUN apk add --no-cache su-exec
+
+# debian/ubuntu-based
+RUN apt-get update && apt-get install -y gosu && rm -rf /var/lib/apt/lists/*
+
+# create a non-root user but do not switch to it via USER
+# uses an example user/group UID/GUID
+RUN addgroup --system scanner && adduser --system --ingroup scanner --no-create-home scanner
+
 COPY ./docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,40 @@
+# --------------------------------------------
+# Stage 1: Alpine builder (for BusyBox static + su-exec)
+# --------------------------------------------
+FROM alpine:3.17 AS builder
+
+# Install a statically-linked BusyBox and su-exec
+RUN apk add --no-cache busybox-static su-exec
+
+# Create a directory to hold our binaries
+RUN mkdir /bundle
+
+# Copy the busybox and su-exec binaries to /bundle
+RUN cp /bin/busybox /bundle/busybox
+RUN cp /sbin/su-exec /bundle/su-exec
+
+# Copy and chmod your entrypoint script
+COPY docker-entrypoint.sh /bundle/docker-entrypoint.sh
+RUN chmod +x /bundle/docker-entrypoint.sh
+
+# --------------------------------------------
+# Stage 2: Lacework inline-scanner final image
+# --------------------------------------------
 FROM lacework/lacework-inline-scanner:0.27.0
 
-# install su-exec/gosu
-# alpine-based
-RUN apk add --no-cache su-exec
+# Copy the static BusyBox + su-exec + entrypoint from the builder
+COPY --from=builder /bundle /bundle
 
-# debian/ubuntu-based
-RUN apt-get update && apt-get install -y gosu && rm -rf /var/lib/apt/lists/*
+# Use BusyBox for shell utilities
+ENV PATH="/bundle:$PATH"
 
-# create a non-root user but do not switch to it via USER
-# uses an example user/group UID/GUID
-RUN addgroup --system scanner && adduser --system --ingroup scanner --no-create-home scanner
+# Manually add a 'scanner' user in /etc/passwd & /etc/group
+RUN echo "scanner:x:10001:10001:scanner user:/home/scanner:/bundle/busybox sh" >> /etc/passwd \
+  && echo "scanner:x:10001:" >> /etc/group
 
-COPY ./docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh
+# Copy the entrypoint script (already +x) to /
+COPY --from=builder /bundle/docker-entrypoint.sh /docker-entrypoint.sh
 
+# Must remain root for GitHub Actions Docker-based actions
 ENTRYPOINT ["/docker-entrypoint.sh"]
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,68 +1,86 @@
-#!/bin/bash
-set -o pipefail
+#!/bundle/busybox sh
+set -eu  # -o pipefail isn't supported by BusyBox sh, but -e + -u = good practice
+
+# Provide safe defaults for environment variables
+: "${INPUT_LW_ACCOUNT_NAME:=}"
+: "${INPUT_LW_ACCESS_TOKEN:=}"
+: "${INPUT_IMAGE_NAME:=}"
+: "${INPUT_IMAGE_TAG:=}"
+: "${INPUT_SCAN_LIBRARY_PACKAGES:=true}"
+: "${INPUT_SAVE_RESULTS_IN_LACEWORK:=false}"
+: "${INPUT_SAVE_BUILD_REPORT:=false}"
+: "${INPUT_BUILD_REPORT_FILE_NAME:=}"
+: "${INPUT_DEBUGGING:=false}"
+: "${INPUT_PRETTY_OUTPUT:=true}"
+: "${INPUT_SIMPLE_OUTPUT:=true}"
+: "${INPUT_COLOR_OUTPUT:=true}"
+: "${INPUT_RESULTS_IN_GITHUB_SUMMARY:=true}"
+: "${INPUT_ADDITIONAL_PARAMETERS:=}"
+: "${LW_SCANNER_DISABLE_UPDATES:=true}"
 
 # Set Lacework credentials as inline scanner environment variable
-export LW_ACCOUNT_NAME=${INPUT_LW_ACCOUNT_NAME}
-export LW_ACCESS_TOKEN=${INPUT_LW_ACCESS_TOKEN}
-
-# Disable update prompt for lw-scanner if newer version is available unless explicitly set
-export LW_SCANNER_DISABLE_UPDATES=${LW_SCANNER_DISABLE_UPDATES:-true}
+export LW_ACCOUNT_NAME="${INPUT_LW_ACCOUNT_NAME}"
+export LW_ACCESS_TOKEN="${INPUT_LW_ACCESS_TOKEN}"
+export LW_SCANNER_DISABLE_UPDATES
 
 # Add parameters based on arguments
-export SCANNER_PARAMETERS=""
-if [ ${INPUT_SCAN_LIBRARY_PACKAGES} = "false" ]; then
-    export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --disable-library-package-scanning"
+SCANNER_PARAMETERS=""
+if [ "$INPUT_SCAN_LIBRARY_PACKAGES" = "false" ]; then
+    SCANNER_PARAMETERS="$SCANNER_PARAMETERS --disable-library-package-scanning"
 fi
-if [ ${INPUT_SAVE_RESULTS_IN_LACEWORK} = "true" ]; then
-    export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --save"
+if [ "$INPUT_SAVE_RESULTS_IN_LACEWORK" = "true" ]; then
+    SCANNER_PARAMETERS="$SCANNER_PARAMETERS --save"
 fi
-if [ ${INPUT_SAVE_BUILD_REPORT} = "true" ]; then
-    export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --html"
+if [ "$INPUT_SAVE_BUILD_REPORT" = "true" ]; then
+    SCANNER_PARAMETERS="$SCANNER_PARAMETERS --html"
 fi
-if [ ! -z "${INPUT_BUILD_REPORT_FILE_NAME}" ]; then
-    export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --html-file ${INPUT_BUILD_REPORT_FILE_NAME}"
+if [ -n "$INPUT_BUILD_REPORT_FILE_NAME" ]; then
+    SCANNER_PARAMETERS="$SCANNER_PARAMETERS --html-file $INPUT_BUILD_REPORT_FILE_NAME"
 fi
-if [ ${INPUT_DEBUGGING} = "true" ]; then
-    export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --debug"
+if [ "$INPUT_DEBUGGING" = "true" ]; then
+    SCANNER_PARAMETERS="$SCANNER_PARAMETERS --debug"
 fi
-if [ ${INPUT_PRETTY_OUTPUT} = "true" ]; then
-    export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --pretty"
+if [ "$INPUT_PRETTY_OUTPUT" = "true" ]; then
+    SCANNER_PARAMETERS="$SCANNER_PARAMETERS --pretty"
 fi
-if [ ${INPUT_SIMPLE_OUTPUT} = "true" ]; then
-    export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --simple"
+if [ "$INPUT_SIMPLE_OUTPUT" = "true" ]; then
+    SCANNER_PARAMETERS="$SCANNER_PARAMETERS --simple"
 fi
-if [ ${INPUT_COLOR_OUTPUT} = "false" ] || [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
-    export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} --no-color"
+# If color is false or we want to print results in a GH summary, disable color
+if [ "$INPUT_COLOR_OUTPUT" = "false" ] || [ "$INPUT_RESULTS_IN_GITHUB_SUMMARY" = "true" ]; then
+    SCANNER_PARAMETERS="$SCANNER_PARAMETERS --no-color"
 fi
-if [ ! -z "${INPUT_ADDITIONAL_PARAMETERS}" ]; then
-    export SCANNER_PARAMETERS="${SCANNER_PARAMETERS} ${INPUT_ADDITIONAL_PARAMETERS}"
+if [ -n "$INPUT_ADDITIONAL_PARAMETERS" ]; then
+    SCANNER_PARAMETERS="$SCANNER_PARAMETERS $INPUT_ADDITIONAL_PARAMETERS"
 fi
 
-# Remove old scanner evaluation, if cached somehow
-rm ${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_*.json &>/dev/null || true
+# Remove old scanner evaluation files, if they exist
+rm -f "${GITHUB_WORKSPACE}/evaluations/${INPUT_IMAGE_NAME}/${INPUT_IMAGE_TAG}/evaluation_"*.json || true
 
-# fix ownership and drop privileges
-# ensure non-root user (scanner) can access workspace
-chown -R scanner:scanner "${GITHUB_WORKSPACE}"
+# Fix ownership so the non-root user can access the workspace
+chown -R 10001:10001 "$GITHUB_WORKSPACE"
 
-# build scanner command separately
-SCANNER_CMD="/app/vulnerability/scanner/lacework/local-scanner/main/local-scanner.binary image evaluate ${INPUT_IMAGE_NAME} ${INPUT_IMAGE_TAG} \
-    --build-plan ${GITHUB_REPOSITORY} \
-    --build-id ${GITHUB_RUN_ID} \
-    --data-directory ${GITHUB_WORKSPACE} \
+# Build the scanner command
+SCANNER_CMD="/app/vulnerability/scanner/lacework/local-scanner/main/local-scanner.binary \
+    image evaluate $INPUT_IMAGE_NAME $INPUT_IMAGE_TAG \
+    --build-plan ${GITHUB_REPOSITORY:-unknown} \
+    --build-id ${GITHUB_RUN_ID:-0} \
+    --data-directory $GITHUB_WORKSPACE \
     --policy \
-    --fail-on-violation-exit-code 1 ${SCANNER_PARAMETERS}"
+    --fail-on-violation-exit-code 1 $SCANNER_PARAMETERS"
 
-# run as non-root (su-exec or gosu)
-# su-exec <user>:<group> <command> ...
-su-exec scanner:scanner $SCANNER_CMD > results.stdout
-export SCANNER_EXIT_CODE=$?
+# Run as non-root (via su-exec)
+echo "Running as non-root user 'scanner'..."
+su-exec scanner:scanner sh -c "$SCANNER_CMD" > results.stdout
+SCANNER_EXIT_CODE=$?
 
-if [ "${INPUT_RESULTS_IN_GITHUB_SUMMARY}" = "true" ]; then
-    echo "### Security Scan" >> $GITHUB_STEP_SUMMARY
-    echo "<pre>" >> $GITHUB_STEP_SUMMARY
-    printf '%s' "$(<results.stdout)" >> $GITHUB_STEP_SUMMARY
-    echo "</pre>" >> $GITHUB_STEP_SUMMARY
+# Print results in GH summary, if desired
+if [ "$INPUT_RESULTS_IN_GITHUB_SUMMARY" = "true" ]; then
+    echo "### Security Scan" >> "$GITHUB_STEP_SUMMARY"
+    echo "<pre>" >> "$GITHUB_STEP_SUMMARY"
+    cat results.stdout >> "$GITHUB_STEP_SUMMARY"
+    echo "</pre>" >> "$GITHUB_STEP_SUMMARY"
 fi
 
-exit ${SCANNER_EXIT_CODE}
+exit "$SCANNER_EXIT_CODE"
+


### PR DESCRIPTION
Ensures the lw-scanner creates its evaluation artifacts under a non-root user, so parallel cleanup jobs or subsequent steps do not encounter permission errors when removing the evaluations directory.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This PR modifies the lw-scanner-action so that while the Docker container starts as root (to comply with GitHub Actions’ requirements), the Lacework scanner process itself runs as a non-root user. This change mitigates the EACCES errors we’ve observed in self-hosted runner environments when other jobs attempt to remove or modify the scanner’s output directory (evaluations/) in parallel.

## Context & Root Cause
1. Mismatch in Execution Contexts:

- The lw-scanner-action runs in a Docker container, which, by default, is launched as root.
- Our repository cleanup steps (and some other parallel jobs) run under a non-root user on the self-hosted runner.
- Consequently, the scanner creates folders and files with root ownership.
- When a subsequent step or parallel job tries to remove these artifacts, it encounters EACCES because it doesn’t have ownership or the necessary privileges to delete root-owned files.

2. Parallel Job Conflicts:

- On self-hosted runners, multiple jobs may share the same workspace.
- If any job tries to clean up the workspace (including the evaluations folder) while another job or step still holds root-level ownership, permissions errors occur intermittently.

## Changes Made

1. Dockerfile:

- Added a scanner user/group (with a known UID/GID).
- Kept root as the default user (i.e., no USER instruction) to satisfy GitHub Actions’ requirement that Docker actions must initially run as root.

2. docker-entrypoint.sh:

- After reading environment variables and constructing the scan command, the script now drops privileges (e.g., via su-exec, gosu, or su) to run local-scanner.binary as the non-root scanner user.
- Updated permissions (using chown) on ${GITHUB_WORKSPACE} so that the non-root user can read/write the evaluations folder.

## Benefits

- Eliminates EACCES Errors: Files and folders are no longer owned by root, so cleanup steps that run as a non-root user can remove or modify them without permission issues.
- Improves Security: Running as a non-root user follows the best practice of least-privilege within containers, reducing the attack surface.

## Notes

- GitHub Actions Limitation: We cannot permanently switch away from root by using the USER directive, because GitHub Actions itself requires the container to launch as root. Our solution is to start the container as root, then drop privileges during the entrypoint script.
- Self-Hosted Runners: Particularly in environments where concurrency is common and the same workspace is shared across parallel jobs, this fix will significantly reduce intermittent permission-related failures.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->